### PR TITLE
Headers setting support when files match a regex

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,17 +30,17 @@ Usage
                      [-t THREADS] [-u USERNAME] [-p PASSWORD]
                      [-i {rackspace,keystone}] [-a AUTH_URL] [-v]
                      {delete,upload,download} ...
-    
+
     Gevent-based, multithreaded tool for interacting with OpenStack Swift and
     Rackspace Cloud Files
-    
+
     positional arguments:
       {delete,upload,download}
         delete              Delete files from specified container
         upload              Upload files to specified container
         download            Download files to specified directory from the
                             specified container
-    
+
     optional arguments:
       -h, --help            show this help message and exit
       --version             show program's version number and exit
@@ -72,6 +72,9 @@ Usage
       -v, --verbose         Enable verbosity. Supply multiple times for additional
                             verbosity. 1) Show Thread Start/Finish, 2) Show Object
                             Name.
+      -H, --headers <file_name_regex>,<header_name>:<header_value>
+                            Set headers returned by RackSpace when serving files matching
+                            a specified regex.
 
 Examples
 --------
@@ -88,3 +91,6 @@ Examples
 
     posthaste -c example -r DFW -u $OS_USERNAME -p $OS_PASSWORD -t 100 delete
 
+Grand access to webfonts across different domains:
+::
+    posthaste -c example -r DFW -u $OS_USERNAME -p $OS_PASSWORD -t 100 upload /path/to/some/dir/ -H ".*\.(eot|otf|woff|ttf)$,Access-Control-Allow-Origin:*"

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Usage
                             Name.
       -H, --headers <file_name_regex>,<header_name>:<header_value>
                             Set headers returned by RackSpace when serving files matching
-                            a specified regex.
+                            a specified regular expression.
 
 Examples
 --------

--- a/posthaste.py
+++ b/posthaste.py
@@ -34,8 +34,6 @@ import time
 
 __version__ = '0.2.2'
 
-FONTS_REGEX = r'.*\.(eot|otf|woff|ttf)$'
-
 HEADER_PAIR_FORMAT = '"<file_name_regex>,<header_name>:<header_value>"'
 
 
@@ -48,7 +46,7 @@ def regex_header_pair(string):
         return (regex, header_name, header_value)
     except:
         raise argparse.ArgumentTypeError(
-            'Headers must be specified in the format: ' + HEADER_PAIR_FORMAT
+            'Headers must be specified in the format: %s' % HEADER_PAIR_FORMAT
         )
 
 


### PR DESCRIPTION
Sometimes it might be useful being able to assign to a file a specific header to be returned by RackSpace when serving the file to the clients.

E.g. it is useful for font files that sometimes need to include an `Access-Control-Allow-Origin: *` header in order to be accessible cross-domain.

This PR tries to add to posthaste a functionality similar to the one provide by Django-cumulus headers (http://django-cumulus.readthedocs.org/en/latest/#headers).