### PR TITLE
Make region argument case insensitive

### DIFF
--- a/posthaste.py
+++ b/posthaste.py
@@ -197,7 +197,7 @@ class Posthaste(object):
             if (service['type'] == 'object-store' and
                     service['name'] in ['cloudFiles', 'swift']):
                 for ep in service['endpoints']:
-                    if ep['region'] == args.region:
+                    if ep['region'].lower() == args.region.lower():
                         endpoint = ep[url_type]
                         break
                 break


### PR DESCRIPTION
Re-opening PR 18 against working branch


Hi,

One for consideration. If you give -r lon, all you get back is 'Endpoint not found', which isn't very informative. 
So either the comparison can be case insensitive, or the error message can be a bit more descriptive.

I'd opt for case insensitive comparison, as ultimately the DNS lookup is case insensitive itself anyway.